### PR TITLE
add status check to LSB init script

### DIFF
--- a/postsrsd.lsb_init.in
+++ b/postsrsd.lsb_init.in
@@ -76,8 +76,21 @@ case "$1" in
 	$0 start
 	ret=$?
 	;;
+  status)
+        log_daemon_msg "postsrsd is running"
+        if [ -s $PIDFILE ]; then
+            PID=`cat $PIDFILE`
+            if kill -0 "$PID" 2>/dev/null; then
+                log_end_msg 0
+            else
+                log_end_msg 1
+            fi
+        else
+            log_end_msg 1
+        fi
+        ;;
   *)
-	echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload|status}" >&2
 	exit 1
 	;;
 esac


### PR DESCRIPTION
I am using postsrsd with puppet and without a status check, puppet always tries to start the daemon, even if it is already running. I've tested this status check and it works for me.
