### PR TITLE
A couple of small fixes: closing listen sockets in child and ignoring EINTR errors from main poll

### DIFF
--- a/postsrsd.c
+++ b/postsrsd.c
@@ -420,6 +420,8 @@ int main (int argc, char **argv)
     char keybuf[1024], *key;
 
     if (poll(fds, 2, 1000) < 0) {
+      if (errno == EINTR)
+        continue;
       if (daemonize)
         syslog (LOG_MAIL | LOG_ERR, "Poll failure: %s", strerror(errno));
       else


### PR DESCRIPTION
Hi,

I noticed when deploying postsrsd on our MX servers that the "restart" option tended to fail because the new process could not open the required sockets for listening. This turned out to be due to the fact that the child processes spawned by the main process still had the listening sockets open.

Attached is a quick fix for this which ensures the child processes close the listen socket FDs once they've forked (they no longer need them). On a related note the main process may want to keep track of its children and kill them when it is killed, but I've not had time to look at how that might be implemented.

Additionally I've included a separate commit which modifies the main poll() loop to ignore EINTR errors. This was making debugging more difficult for me because it caused the process to exit whenever I attached 'strace' to it. It should be safe to ignore EINTR here as any signals sent to the process will either cause it to exit anyway or be ignored.

Thanks,
Chris
