### PR TITLE
Remove addrinfo flags

### DIFF
--- a/postsrsd.c
+++ b/postsrsd.c
@@ -58,7 +58,7 @@ static int bind_service (const char *service, int family)
   memset (&hints, 0, sizeof(hints));
   hints.ai_family = family;
   hints.ai_socktype = SOCK_STREAM;
-  hints.ai_flags = AI_ADDRCONFIG | AI_V4MAPPED;
+
   err = getaddrinfo(NULL, service, &hints, &addr);
   if (err != 0) {
     fprintf(stderr, "%s: bind_service(%s): %s\n", self, service, gai_strerror(err));


### PR DESCRIPTION
Remove flags since they require the network to be up and routable for no reason. Simply put if down `ip link set eth0 down` and postsrsd won't start anymore. Since postsrsd is supposed to bind to localhost anyways, we don't need these ai_flags. This also solves all the failed start attempts on boot.