### PR TITLE
Read config from directly from environment

### DIFF
--- a/init/postsrsd.systemd.in
+++ b/init/postsrsd.systemd.in
@@ -1,6 +1,5 @@
 [Unit]
 Description=PostSRSd Daemon
-After=network.target
 
 [Service]
 Type=simple
@@ -12,4 +11,3 @@ Restart=always
 
 [Install]
 WantedBy=multi-user.target
-

--- a/postsrsd.c
+++ b/postsrsd.c
@@ -74,7 +74,7 @@ static int bind_service (const char *service, int family)
     flags = fcntl (sock, F_GETFL, 0);
     if (flags < 0) goto fail;
     if (fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) goto fail;
-    break;
+    continue;
   fail:
     err = errno;
     if (sock >= 0) close (sock);
@@ -235,7 +235,7 @@ typedef void(*handle_t)(srs_t*, FILE*, const char*, const char*, const char**);
 
 int main (int argc, char **argv)
 {
-  int opt, timeout = 1800, family = AF_INET;
+  int opt, timeout = 1800, family = AF_UNSPEC;
   int daemonize = FALSE;
   char *forward_service = NULL, *reverse_service = NULL,
        *user = NULL, *domain = NULL, *chroot_dir = NULL;

--- a/postsrsd.c
+++ b/postsrsd.c
@@ -74,7 +74,7 @@ static int bind_service (const char *service, int family)
     flags = fcntl (sock, F_GETFL, 0);
     if (flags < 0) goto fail;
     if (fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) goto fail;
-    continue;
+    break;
   fail:
     err = errno;
     if (sock >= 0) close (sock);
@@ -236,7 +236,7 @@ typedef void(*handle_t)(srs_t*, FILE*, const char*, const char*, const char**);
 
 int main (int argc, char **argv)
 {
-  int opt, timeout = 1800, family = AF_UNSPEC;
+  int opt, timeout = 1800, family = AF_INET;
   int daemonize = FALSE;
   char *forward_service = NULL, *reverse_service = NULL,
        *user = NULL, *domain = NULL, *chroot_dir = NULL;


### PR DESCRIPTION
This pull request introduces the `-e` command line parameter, which activates the reading of configuration options from the environment directly without having to pass in every single one of them by a separate option. This works fine for me for a while now.

Moreover, if -4 and -6 are omitted, postsrsd now binds to both ipv4' and ipv6' localhost.