### PR TITLE
add the ability to set the socket listen address

### DIFF
--- a/postsrsd.c
+++ b/postsrsd.c
@@ -48,7 +48,7 @@
 
 static char *self = NULL;
 
-static size_t bind_service (const char *service, int family, int* socks, size_t max_socks)
+static size_t bind_service (const char *listen_addr, const char *service, int family, int* socks, size_t max_socks)
 {
   struct addrinfo *addr, *it;
   struct addrinfo hints;
@@ -60,7 +60,7 @@ static size_t bind_service (const char *service, int family, int* socks, size_t 
   hints.ai_family = family;
   hints.ai_socktype = SOCK_STREAM;
 
-  err = getaddrinfo(NULL, service, &hints, &addr);
+  err = getaddrinfo(listen_addr, service, &hints, &addr);
   if (err != 0) {
     fprintf(stderr, "%s: bind_service(%s): %s\n", self, service, gai_strerror(err));
     return count;
@@ -219,6 +219,7 @@ static void show_help ()
     "   -s<file>       read secrets from file (required)\n"
     "   -d<domain>     set domain name for rewrite (required)\n"
     "   -a<char>       set first separator character which can be one of: -=+ (default: =)\n"
+    "   -l<addr>       set socket listen address (default: 127.0.0.1)\n"
     "   -f<port>       set port for the forward SRS lookup (default: 10001)\n"
     "   -r<port>       set port for the reverse SRS lookup (default: 10002)\n"
     "   -p<pidfile>    write process ID to pidfile (default: none)\n"
@@ -243,7 +244,7 @@ int main (int argc, char **argv)
 {
   int opt, timeout = 1800, family = AF_UNSPEC;
   int daemonize = FALSE;
-  char *forward_service = NULL, *reverse_service = NULL,
+  char *listen_addr = NULL, *forward_service = NULL, *reverse_service = NULL,
        *user = NULL, *domain = NULL, *chroot_dir = NULL;
   char separator = '=';
   char *secret_file = NULL, *pid_file = NULL;
@@ -264,7 +265,7 @@ int main (int argc, char **argv)
   tmp = strrchr(argv[0], '/');
   if (tmp) self = strdup(tmp + 1); else self = strdup(argv[0]);
 
-  while ((opt = getopt(argc, argv, "46d:a:f:r:s:u:t:p:c:X::Dhev")) != -1) {
+  while ((opt = getopt(argc, argv, "46d:a:l:f:r:s:u:t:p:c:X::Dhev")) != -1) {
     switch (opt) {
       case '?':
         return EXIT_FAILURE;
@@ -279,6 +280,9 @@ int main (int argc, char **argv)
         break;
       case 'a':
         separator = *optarg;
+        break;
+      case 'l':
+        listen_addr = strdup(optarg);
         break;
       case 'f':
         forward_service = strdup(optarg);
@@ -404,11 +408,11 @@ int main (int argc, char **argv)
     return EXIT_FAILURE;
   }
   /* Bind ports. May require privileges if the config specifies ports below 1024 */
-  sc = bind_service(forward_service, family, &sockets[socket_count], 4 - socket_count);
+  sc = bind_service(listen_addr, forward_service, family, &sockets[socket_count], 4 - socket_count);
   if (sc == 0) return EXIT_FAILURE;
   while (sc-- > 0) handler[socket_count++] = handle_forward;
   free (forward_service);
-  sc = bind_service(reverse_service, family, &sockets[socket_count], 4 - socket_count);
+  sc = bind_service(listen_addr, reverse_service, family, &sockets[socket_count], 4 - socket_count);
   if (sc == 0) return EXIT_FAILURE;
   while (sc-- > 0) handler[socket_count++] = handle_reverse;
   free (reverse_service);


### PR DESCRIPTION
I'm running postsrsd in a FreeBSD jail and the default loopback address 127.0.0.1 is not available so `getaddrinfo()` returns the jail's public IP. There is a "pseudo-loopback" address on lo1 (172.0.0.x) which I would prefer to bind to but there's was no option to specify the listen address. Without this, I have to resort to blocking ports in the firewall.

Not sure how this affects IPv6, but for IPv4 this fix is straight forward.