### PR TITLE
Exit with failure if test in the init script has failed.

### DIFF
--- a/init/postsrsd.sysv-lsb.in
+++ b/init/postsrsd.sysv-lsb.in
@@ -34,7 +34,7 @@ SRS_EXCLUDE_DOMAINS=
 # Read config file
 . @CONFIG_DIR@/$NAME
 
-test -r "$SRS_SECRET" -a -n "$SRS_DOMAIN" || exit 0
+test -r "$SRS_SECRET" -a -n "$SRS_DOMAIN" || exit 1
 
 ret=0
 case "$1" in


### PR DESCRIPTION
Please, change test's failure exit code in init script. Currently the success is reported, but nothing happens :-) 