### PR TITLE
Add Postforward link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Known Issues
   will always be rewritten even if the mail is not forwarded at all. This
   is because the canonical maps are read by the cleanup daemon, which
   processes mails at the very beginning before any routing decision is made.
+  
+  Where piping into an external command is not a problem,
+  [Postforward](https://github.com/zoni/postforward) offers an alternative
+  way to integrate PostSRSd with Postfix which avoids this problem.
 
 - The Postfix package in CentOS 6 lacks the required support for TCP
   dictionaries. Please upgrade your distribution or build Postfix yourself.


### PR DESCRIPTION
Due to the way PostSRSd currently interfaces with Postfix, addresses are rewritten regardless of forwarding taking place or not. Up until now that's always stopped me from adopting PostSRSd for my private mail server because the burden of mangled Return-Path headers did not hold up against the one user who was forwarding mails but could simply whitelist my MX on the other end.

I've now written a small filter of sorts, [Postforward](https://github.com/zoni/postforward), which does SRS using PostSRSd coupled with it's own forwarding (by re-injecting rewritten mail using sendmail) to overcome this limitation at the cost of more complex configuration. While not ideal for all setups, I believe it may be useful enough for some users to warrant a reference in the README.