### PR TITLE
Hook-up endianness & sizeof(long) detection code in SHA-1 implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.4)
 project(postsrsd C)
 include(CheckIncludeFile)
+include(CheckTypeSize)
+include(TestBigEndian)
 
 option(GENERATE_SRS_SECRET "Generate a random SRS secret if none exists during install" ON)
 option(USE_APPARMOR "Enable AppArmor profile" OFF)
@@ -55,6 +57,13 @@ check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 if(HAVE_SYS_TYPES_H)
     add_definitions(-DHAVE_SYS_TYPES_H)
 endif()
+
+test_big_endian(WORDS_BIGENDIAN)
+if(WORDS_BIGENDIAN)
+    add_definitions(-DWORDS_BIGENDIAN)
+endif()
+check_type_size("unsigned long" SIZEOF_UNSIGNED_LONG)
+add_definitions(-DSIZEOF_UNSIGNED_LONG=${SIZEOF_UNSIGNED_LONG})
 
 if(NOT DEFINED INIT_FLAVOR)
     if(SYSTEMD)

--- a/sha1.c
+++ b/sha1.c
@@ -29,12 +29,21 @@
 #endif
 #endif
 
-#ifdef WORDS_BIGENDIAN
-#define BYTEORDER 0x4321
+#if SIZEOF_UNSIGNED_LONG == 4
+#  ifdef WORDS_BIGENDIAN
+#    define BYTEORDER 0x4321
+#  else
+#    define BYTEORDER 0x1234
+#  endif
+#elif SIZEOF_UNSIGNED_LONG == 8
+#  ifdef WORDS_BIGENDIAN
+#    define BYTEORDER 0x87654321
+#  else
+#    define BYTEORDER 0x12345678
+#  endif
 #else
-#define BYTEORDER 0x1234
+#  error "SHA1 requires an unsigned long of either 4 or 8 bytes"
 #endif
-
 
 /* UNRAVEL should be fastest & biggest */
 /* UNROLL_LOOPS should be just as big, but slightly slower */


### PR DESCRIPTION
This makes the SHA-1 implementation valid for big endian architectures as well.

(This was triggered by a build failure of the Debian packaging on s390x, see https://buildd.debian.org/status/fetch.php?pkg=postsrsd&arch=s390x&ver=1.5-1&stamp=1548202296&raw=0).