### PR TITLE
Add setgid capability to AppArmor profile

### DIFF
--- a/init/postsrsd.apparmor.in
+++ b/init/postsrsd.apparmor.in
@@ -5,6 +5,7 @@
   #include <abstractions/nameservice>
 
   capability setuid,
+  capability setgid,
   capability sys_chroot,
   /etc/postsrsd.secret r,
   @CMAKE_INSTALL_PREFIX@/sbin/@POSTSRSD@ mr,


### PR DESCRIPTION
Commit 766720e1ac made postsrsd also drop group privileges using `setgid`, but the setgid capability wasn't added to the AppArmor profile. This resulted in the `setgid()` call failing with `EPERM` on systems with AppArmor enabled, such as Debian.