### PR TITLE
Update postsrsd.c

### DIFF
--- a/postsrsd.c
+++ b/postsrsd.c
@@ -669,11 +669,13 @@ int main(int argc, char **argv)
                     continue;
                 /* remove the nonblocking flag for OSes that bequeath it */
                 flags = fcntl(conn, F_GETFL, 0);
-                if (flags < 0) {
+                if (flags < 0)
+                {
                     close(conn);
                     continue;
                 }
-                if (fcntl(conn, F_SETFL, flags & ~O_NONBLOCK) < 0) {
+                if (fcntl(conn, F_SETFL, flags & ~O_NONBLOCK) < 0)
+                {
                     close(conn);
                     continue;
                 }


### PR DESCRIPTION
Some OSes like e.g. the BSDs have the connection inherit O_NONBLOCK.
The result does not prevent postsrsd from working, but causes a syslogged error for roughly every other connection from cleanup.
Removing the flag is a NOP if it's not set, so this change doesn't require an OS-dependent ifdef.