### PR TITLE
Scope reverse SRS rejection to local domains (fixes 451 for transiting SRS mail)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@
 Changelog
 #########
 
+Unreleased
+==========
+
+Fixed
+-----
+
+* ``reverse`` no longer rejects (socketmap ``PERM`` / milter reject) SRS
+  addresses whose domain is not local. Such addresses are minted by a
+  different SRS signer and only transit this host (relay, backup MX,
+  multi-hop forwarding); they are passed through unchanged again, as in
+  2.1.0 and earlier. Unverifiable SRS addresses in a local domain (forged
+  backscatter) are still rejected.
+
 2.2.1
 =====
 

--- a/src/main.c
+++ b/src/main.c
@@ -489,7 +489,8 @@ static void handle_socketmap_client(postsrsd_t* state, int conn)
         }
         else if (strcmp(query_type, "reverse") == 0)
         {
-            rewritten = postsrsd_reverse(addr, state->srs, db, &error, &info,
+            rewritten = postsrsd_reverse(addr, state->srs, db,
+                                         state->local_domains, &error, &info,
                                          "socketmap");
         }
         else
@@ -686,8 +687,8 @@ static void handle_milter_client(postsrsd_t* state, int conn)
                 {
                     char* rcpt = list_get(recipients, i);
                     char* rewritten = postsrsd_reverse(
-                        rcpt, state->srs, db, &error, &info,
-                        queue_id != NULL ? queue_id : "NOQUEUE");
+                        rcpt, state->srs, db, state->local_domains, &error,
+                        &info, queue_id != NULL ? queue_id : "NOQUEUE");
                     if (rewritten)
                     {
                         char* bracketed_old_rcpt = add_brackets(rcpt);

--- a/src/main.c
+++ b/src/main.c
@@ -489,9 +489,9 @@ static void handle_socketmap_client(postsrsd_t* state, int conn)
         }
         else if (strcmp(query_type, "reverse") == 0)
         {
-            rewritten = postsrsd_reverse(addr, state->srs, db,
-                                         state->local_domains, &error, &info,
-                                         "socketmap");
+            rewritten =
+                postsrsd_reverse(addr, state->srs, db, state->local_domains,
+                                 &error, &info, "socketmap");
         }
         else
         {

--- a/src/srs.c
+++ b/src/srs.c
@@ -107,7 +107,8 @@ char* postsrsd_forward(const char* addr, const char* domain, srs_t* srs,
 }
 
 char* postsrsd_reverse(const char* addr, srs_t* srs, database_t* db,
-                       bool* error, const char** info, const char* queue_id)
+                       domain_set_t* local_domains, bool* error,
+                       const char** info, const char* queue_id)
 {
     char buffer[513];
     if (addr == NULL)
@@ -121,11 +122,20 @@ char* postsrsd_reverse(const char* addr, srs_t* srs, database_t* db,
     int result = srs_reverse(srs, buffer, sizeof(buffer), addr);
     if (result != SRS_SUCCESS)
     {
+        /* A failed reverse only constitutes (forged) backscatter worth
+         * rejecting if the address claims a domain we actually sign SRS for.
+         * A hash/timestamp failure in any other domain just means the address
+         * was minted by a different SRS signer and is merely transiting this
+         * host (relay, backup MX, multi-hop forwarding); it must pass through
+         * untouched so delivery can proceed, rather than being deferred by a
+         * socketmap PERM (Postfix 451 4.3.5). */
+        const char* at = strrchr(addr, '@');
+        bool ours = at != NULL && domain_set_contains(local_domains, at + 1);
         if (error != NULL)
-            *error = result != SRS_ENOTSRSADDRESS;
+            *error = result != SRS_ENOTSRSADDRESS && ours;
         if (info != NULL)
             *info = srs_strerror(result);
-        if (result != SRS_ENOTSRSADDRESS)
+        if (result != SRS_ENOTSRSADDRESS && ours)
         {
             log_info("%s: <%s> not reversed: %s", queue_id, addr,
                      srs_strerror(result));

--- a/src/srs.h
+++ b/src/srs.h
@@ -27,6 +27,7 @@ char* postsrsd_forward(const char* addr, const char* domain, srs_t* srs,
                        database_t* db, domain_set_t* local_domains, bool* error,
                        const char** info, const char* queue_id);
 char* postsrsd_reverse(const char* addr, srs_t* srs, database_t* db,
-                       bool* error, const char** info, const char* queue_id);
+                       domain_set_t* local_domains, bool* error,
+                       const char** info, const char* queue_id);
 
 #endif

--- a/tests/blackbox/socketmap.py
+++ b/tests/blackbox/socketmap.py
@@ -279,6 +279,14 @@ STATELESS_QUERIES = [
         "reverse SRS0=FAKE=2V=otherdomain.com=test@example.com",
         "PERM Hash invalid in SRS address.",
     ),
+    # Pass through (do not reject) an SRS address in a domain we do not sign
+    # for: its hash can never validate under our secret because it was minted
+    # by a different signer and is only transiting this host. Rejecting it
+    # would defer legitimate relay / backup-MX / multi-hop forwarding.
+    (
+        "reverse SRS0=FAKE=2V=otherdomain.com=test@foreign.example",
+        "NOTFOUND Hash invalid in SRS address.",
+    ),
     # Recover mail address from all-lowercase SRS0 address
     (
         "reverse srs0=xjo9=2v=otherdomain.com=test@example.com",


### PR DESCRIPTION
## Problem

Since the milter rewrite, a `reverse` socketmap query for any SRS-shaped recipient whose hash does not validate returns `PERM`, which Postfix surfaces as `451 4.3.5 Server configuration error` from `recipient_canonical_maps`. Because canonical maps are evaluated for **every** recipient, this defers all mail to that recipient.

This breaks relay / backup-MX / multi-hop forwarding: an SRS return-path minted by a *different* signer (a foreign SRS domain merely transiting the host) can never validate under our secret, yet it is now hard-deferred on an endless retry loop instead of being passed through.

Up to and including 2.1.0, `reverse` returned `NOTFOUND` (passthrough) for such addresses and the mail flowed on to normal delivery.

## Reproduction

```console
$ postmap -q "srs0=xemc=et=bluewin.ch=user@foreign.example" \
        socketmap:unix:/var/spool/postfix/srs:reverse
postmap: warning: socketmap:...:reverse socketmap server permanent error: Hash invalid in SRS address.
postmap: fatal: table socketmap:...:reverse: query error
```

The corresponding daemon log line:

```
postsrsd: socketmap: <srs0=xemc=et=bluewin.ch=user@foreign.example> not reversed: Hash invalid in SRS address.
```

and Postfix's reaction:

```
warning: socketmap:unix:srs:reverse socketmap server permanent error: Hash invalid in SRS address.
warning: socketmap:unix:srs:reverse lookup error for "srs0=xemc=et=bluewin.ch=user@foreign.example"
NOQUEUE: reject: RCPT from ...: 451 4.3.5 Server configuration error
```

## Root cause

Commit 67676fd ("Rewrite milter without libmilter dependency", first released in **2.2.0**; absent in 2.1.0) added the following to `postsrsd_reverse()` so the new milter can `milter_reject()`:

```c
if (error != NULL)
    *error = result != SRS_ENOTSRSADDRESS;
```

That `error` flag is **shared** with the socketmap handler, where it is turned into a `PERM` reply. As a result, the flag is set for any address that parses as SRS but fails to reverse (invalid hash, expired timestamp, …) regardless of whether the address is in a domain we actually sign SRS for.

## Fix

Scope the rejection to recipients in a **local domain** (which, since 2.2.1, includes `srs-domain`):

```c
const char* at = strrchr(addr, '@');
bool ours = at != NULL && domain_set_contains(local_domains, at + 1);
if (error != NULL)
    *error = result != SRS_ENOTSRSADDRESS && ours;
```

- An unverifiable SRS address **in one of our domains** is still rejected as forged backscatter (`PERM` / milter reject) — unchanged behavior.
- An SRS address **in a foreign domain** can never validate under our secret; it is passed through (`NOTFOUND`) again, as in 2.1.0 and earlier.

This requires threading `local_domains` into `postsrsd_reverse()` (symmetric with `postsrsd_forward()`, which already receives it) and passing `state->local_domains` at both call sites in `main.c`.

## Why existing behavior and tests are preserved

Every rejected case in `tests/blackbox/socketmap.py` uses an address in the configured domain (`@example.com`), so it remains `ours == true` and continues to return `PERM`. The blackbox suite stays green.

A regression test for the foreign-domain case is added:

```python
# Pass through (do not reject) an SRS address in a domain we do not sign
# for: its hash can never validate under our secret because it was minted
# by a different signer and is only transiting this host. Rejecting it
# would defer legitimate relay / backup-MX / multi-hop forwarding.
(
    "reverse SRS0=FAKE=2V=otherdomain.com=test@foreign.example",
    "NOTFOUND Hash invalid in SRS address.",
),
```

## Notes

- This also affects the milter path: a foreign SRS recipient is no longer milter-rejected. That is the same correctness argument, but flagging it explicitly so it is a deliberate decision rather than a surprise.
- If a tighter gate is preferred, the check can be scoped to the exact `srs-domain` (`strcasecmp` against `state->srs_domain`) instead of the whole `local_domains` set. Happy to switch if that is the preferred semantics.